### PR TITLE
feat: Namespaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,6 +308,7 @@ dependencies = [
  "human-panic",
  "serde",
  "serde_json",
+ "snailquote",
  "tokio",
  "tree-sitter",
  "tree-sitter-go",
@@ -979,6 +980,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
+name = "snailquote"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec62a949bda7f15800481a711909f946e1204f2460f89210eaf7f57730f88f86"
+dependencies = [
+ "thiserror",
+ "unicode_categories",
+]
+
+[[package]]
 name = "socket2"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1023,6 +1034,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.11",
 ]
 
 [[package]]
@@ -1205,6 +1236,12 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ flipt = "0.4.1"
 human-panic = "1.1.3"
 serde = "1.0.159"
 serde_json = "1.0.95"
+snailquote = "0.3.1"
 tokio = { version = "1", features = ["full"] }
 tree-sitter = "0.20.9"
 tree-sitter-go = "0.19.1"

--- a/examples/go/basic.go
+++ b/examples/go/basic.go
@@ -13,24 +13,27 @@ store.On("GetEvaluationRules", mock.Anything, mock.Anything, "foo").Return([]*st
 
 // this is a comment that mentions the flagKey 'foo' but should not be included in the output
 resp, err := s.Evaluate(context.TODO(), &flipt.EvaluationRequest{
-	EntityId: "1",
-	FlagKey:  "foo",
+	EntityId:     "1",
+	NamespaceKey: "default",
+	FlagKey:      "foo",
 	Context: map[string]string{
 		"bar": "boz",
 	},
 })
 
 resp, err = s.Evaluate(context.TODO(), &flipt.EvaluationRequest{
-	EntityId: "1",
-	FlagKey:  "bar",
+	EntityId:     "1",
+	NamespaceKey: "production",
+	FlagKey:      "bar",
 	Context: map[string]string{
 		"bar": "boz",
 	},
 })
 
 resp, err = s.Evaluate(context.TODO(), &flipt.EvaluationRequest{
-	EntityId: "1",
-	FlagKey:  "boz",
+	EntityId:     "1",
+	NamespaceKey: "default",
+	FlagKey:      "boz",
 	Context: map[string]string{
 		"bar": "boz",
 	},

--- a/rules/go.scm
+++ b/rules/go.scm
@@ -1,14 +1,19 @@
 (call_expression
-  function: (_) @_fn (#match? @_fn "(GetFlag|Evaluate)")
-    arguments: (argument_list
-     (unary_expression
-       (composite_literal
-         body: (_
-           (keyed_element
-            (interpreted_string_literal) @v
-            ) @k (#match? @k "(Key|FlagKey)")
-         )
-       )
-     )
+  function: (_ (field_identifier) @_name (#match? @_name "(GetFlag|Evaluate)"))
+  arguments: (_ 
+    (unary_expression
+      operand: (_
+        body: (_ 
+          (keyed_element
+            (field_identifier)? @_namespaceKey (#match? @_namespaceKey "NamespaceKey")
+            (interpreted_string_literal) @namespaceValue
+          )
+          (keyed_element
+            (field_identifier) @_flagKey (#match? @_flagKey "(Key|FlagKey)")
+            (interpreted_string_literal) @flagValue
+          )
+        ) @arg
+      ) 
+    ) 
   )
 ) @call

--- a/rules/go.scm
+++ b/rules/go.scm
@@ -5,9 +5,9 @@
       operand: (_
         body: (_ 
           (keyed_element
-            (field_identifier)? @_namespaceKey (#match? @_namespaceKey "NamespaceKey")
+            (field_identifier) @_namespaceKey (#match? @_namespaceKey "NamespaceKey")
             (interpreted_string_literal) @namespaceValue
-          )
+          )?
           (keyed_element
             (field_identifier) @_flagKey (#match? @_flagKey "(Key|FlagKey)")
             (interpreted_string_literal) @flagValue

--- a/src/ffs/scanner.rs
+++ b/src/ffs/scanner.rs
@@ -3,6 +3,7 @@ use crate::types::{
     language::{Language, SupportedLanguage},
 };
 use anyhow::{Ok, Result};
+use snailquote::unescape;
 use std::fs;
 use tree_sitter::{Query, QueryCursor};
 use walkdir::{DirEntry, WalkDir};
@@ -65,25 +66,19 @@ impl Scanner {
                         .captures
                         .iter()
                         .find(|c| c.index == namespace_index)
-                        .unwrap()
-                        .node
-                        .utf8_text(code.as_bytes())
-                        .unwrap_or("default");
+                        .and_then(|f| f.node.utf8_text(code.as_bytes()).ok());
 
                     let flag_key = each_match
                         .captures
                         .iter()
                         .find(|c| c.index == flag_index)
-                        .unwrap()
-                        .node
-                        .utf8_text(code.as_bytes())
-                        .unwrap_or_default();
+                        .and_then(|f| f.node.utf8_text(code.as_bytes()).ok());
 
                     let range = capture.node.range();
 
                     let flag = Flag {
-                        namespace_key: namespace_key.to_string(),
-                        key: flag_key.to_string(),
+                        namespace_key: unescape(namespace_key.unwrap_or("default")).unwrap(),
+                        key: unescape(flag_key.unwrap()).unwrap(),
                         loc: Location {
                             file: path.to_string(),
                             line: range.start_point.row,

--- a/src/ffs/scanner.rs
+++ b/src/ffs/scanner.rs
@@ -1,7 +1,8 @@
-use crate::types::language::{Language, SupportedLanguage};
-use crate::types::token::{Location, TokenSet};
+use crate::types::{
+    flag::{Flag, Location},
+    language::{Language, SupportedLanguage},
+};
 use anyhow::{Ok, Result};
-use std::collections::HashMap;
 use std::fs;
 use tree_sitter::{Query, QueryCursor};
 use walkdir::{DirEntry, WalkDir};
@@ -17,8 +18,8 @@ impl Scanner {
     }
 
     /// Scan the directory for files for the given language and find all flag keys along with their locations.
-    pub fn scan(&mut self) -> Result<TokenSet> {
-        let mut tokens: TokenSet = HashMap::new();
+    pub fn scan(&mut self) -> Result<Vec<Flag>> {
+        let mut flags = Vec::new();
 
         let dir = match self.dir.to_owned() {
             Some(s) => s,
@@ -43,10 +44,59 @@ impl Scanner {
             .filter(|e| is_file_ext(e, &ll.file_extension))
         {
             let path = entry.path().to_str().unwrap();
-            parse_file(path, &mut parser, &query, &mut tokens)?;
+
+            let code = fs::read_to_string(path).expect("Unable to read file");
+            let parsed = parser.parse(&code, None).expect("Error parsing code");
+
+            let mut query_cursor = QueryCursor::new();
+            let fn_arg_index = query.capture_index_for_name("arg").unwrap();
+
+            for each_match in query_cursor.matches(&query, parsed.root_node(), code.as_bytes()) {
+                for capture in each_match
+                    .captures
+                    .iter()
+                    .filter(|c| c.index == fn_arg_index)
+                {
+                    // get namespace and flag key from the function call
+                    let namespace_index = query.capture_index_for_name("namespaceValue").unwrap();
+                    let flag_index = query.capture_index_for_name("flagValue").unwrap();
+
+                    let namespace_key = each_match
+                        .captures
+                        .iter()
+                        .find(|c| c.index == namespace_index)
+                        .unwrap()
+                        .node
+                        .utf8_text(code.as_bytes())
+                        .unwrap_or("default");
+
+                    let flag_key = each_match
+                        .captures
+                        .iter()
+                        .find(|c| c.index == flag_index)
+                        .unwrap()
+                        .node
+                        .utf8_text(code.as_bytes())
+                        .unwrap_or_default();
+
+                    let range = capture.node.range();
+
+                    let flag = Flag {
+                        namespace_key: namespace_key.to_string(),
+                        key: flag_key.to_string(),
+                        loc: Location {
+                            file: path.to_string(),
+                            line: range.start_point.row,
+                            column: range.start_point.column,
+                        },
+                    };
+
+                    flags.push(flag.clone());
+                }
+            }
         }
 
-        Ok(tokens)
+        Ok(flags)
     }
 }
 
@@ -56,41 +106,4 @@ fn is_file_ext(entry: &DirEntry, ext: &str) -> bool {
         .to_str()
         .map(|s| s.ends_with(ext))
         .unwrap_or(false)
-}
-
-fn parse_file(
-    input: &str,
-    parser: &mut tree_sitter::Parser,
-    query: &tree_sitter::Query,
-    col: &mut HashMap<String, Vec<Location>>,
-) -> Result<()> {
-    let code = fs::read_to_string(input).expect("Unable to read file");
-    let parsed = parser.parse(&code, None).expect("Error parsing code");
-
-    let mut query_cursor = QueryCursor::new();
-    let all_matches = query_cursor.matches(query, parsed.root_node(), code.as_bytes());
-    let flag_key_idx = query.capture_index_for_name("v").unwrap();
-
-    for each_match in all_matches {
-        for capture in each_match
-            .captures
-            .iter()
-            .filter(|c| c.index == flag_key_idx)
-        {
-            let range = capture.node.range();
-            let text = &code[range.start_byte..range.end_byte];
-            let line = range.start_point.row;
-            let column = range.start_point.column;
-
-            let loc = Location {
-                file: input.to_string(),
-                line,
-                column,
-            };
-
-            col.entry(text.to_string()).or_default().push(loc);
-        }
-    }
-
-    Ok(())
 }

--- a/src/ffs/scanner.rs
+++ b/src/ffs/scanner.rs
@@ -62,17 +62,19 @@ impl Scanner {
                     let namespace_index = query.capture_index_for_name("namespaceValue").unwrap();
                     let flag_index = query.capture_index_for_name("flagValue").unwrap();
 
+                    // TODO: there is probably a more efficient way to do this since we are iterating over the captures again
                     let namespace_key = each_match
                         .captures
                         .iter()
                         .find(|c| c.index == namespace_index)
-                        .and_then(|f| f.node.utf8_text(code.as_bytes()).ok());
+                        .and_then(|c| c.node.utf8_text(code.as_bytes()).ok());
 
+                    // TODO: there is probably a more efficient way to do this since we are iterating over the captures again
                     let flag_key = each_match
                         .captures
                         .iter()
                         .find(|c| c.index == flag_index)
-                        .and_then(|f| f.node.utf8_text(code.as_bytes()).ok());
+                        .and_then(|c| c.node.utf8_text(code.as_bytes()).ok());
 
                     let range = capture.node.range();
 

--- a/src/ffs/scanner.rs
+++ b/src/ffs/scanner.rs
@@ -81,8 +81,10 @@ impl Scanner {
                         flag_key: unescape(flag_key.unwrap()).unwrap(),
                         location: Location {
                             file: path.to_string(),
-                            line: range.start_point.row,
-                            column: range.start_point.column,
+                            start_line: range.start_point.row,
+                            start_column: range.start_point.column,
+                            end_line: range.end_point.row,
+                            end_column: range.end_point.column,
                         },
                     };
 

--- a/src/ffs/scanner.rs
+++ b/src/ffs/scanner.rs
@@ -78,8 +78,8 @@ impl Scanner {
 
                     let flag = Flag {
                         namespace_key: unescape(namespace_key.unwrap_or("default")).unwrap(),
-                        key: unescape(flag_key.unwrap()).unwrap(),
-                        loc: Location {
+                        flag_key: unescape(flag_key.unwrap()).unwrap(),
+                        location: Location {
                             file: path.to_string(),
                             line: range.start_point.row,
                             column: range.start_point.column,

--- a/src/ffs/scanner.rs
+++ b/src/ffs/scanner.rs
@@ -51,6 +51,8 @@ impl Scanner {
 
             let mut query_cursor = QueryCursor::new();
             let fn_arg_index = query.capture_index_for_name("arg").unwrap();
+            let namespace_index = query.capture_index_for_name("namespaceValue").unwrap();
+            let flag_index = query.capture_index_for_name("flagValue").unwrap();
 
             for each_match in query_cursor.matches(&query, parsed.root_node(), code.as_bytes()) {
                 for capture in each_match
@@ -58,10 +60,6 @@ impl Scanner {
                     .iter()
                     .filter(|c| c.index == fn_arg_index)
                 {
-                    // get namespace and flag key from the function call
-                    let namespace_index = query.capture_index_for_name("namespaceValue").unwrap();
-                    let flag_index = query.capture_index_for_name("flagValue").unwrap();
-
                     // TODO: there is probably a more efficient way to do this since we are iterating over the captures again
                     let namespace_key = each_match
                         .captures
@@ -78,7 +76,7 @@ impl Scanner {
 
                     let range = capture.node.range();
 
-                    let flag = Flag {
+                    flags.push(Flag {
                         namespace_key: unescape(namespace_key.unwrap_or("default")).unwrap(),
                         flag_key: unescape(flag_key.unwrap()).unwrap(),
                         location: Location {
@@ -88,9 +86,7 @@ impl Scanner {
                             end_line: range.end_point.row,
                             end_column: range.end_point.column,
                         },
-                    };
-
-                    flags.push(flag.clone());
+                    });
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,58 +1,50 @@
 use anyhow::{Ok, Result};
 use clap::Parser;
 use human_panic::setup_panic;
-use types::token::{Token, TokenSet};
+use types::flag::Flag;
 
 use crate::{ffs::scanner::Scanner, types::args::Args};
 mod ffs;
 mod types;
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
     setup_panic!();
 
     let args = Args::parse();
 
     let mut ffs = Scanner::new(args.language, args.dir);
-    let tokens = ffs.scan()?;
+    let flags = ffs.scan()?;
+    write_output(flags, args.output)?;
 
-    flipt::meta::MetaClient::new(flipt::Config::default())?
-        .info()
-        .get()
-        .await?;
-
-    let flipt_client = flipt::api::ApiClient::new(flipt::Config::default())?;
-
-    for k in tokens.keys() {
-        flipt_client
-            .flags()
-            .get(&flipt::api::flag::FlagGetRequest {
-                namespace_key: None,
-                key: k.to_string(),
-            })
-            .await?;
-    }
-
+    // flipt::meta::MetaClient::new(flipt::Config::default())?
+    //     .info()
+    //     .get()
+    //     .await?;
+    //
+    // let flipt_client = flipt::api::ApiClient::new(flipt::Config::default())?;
+    //
+    // for k in tokens.keys() {
+    //     flipt_client
+    //         .flags()
+    //         .get(&flipt::api::flag::FlagGetRequest {
+    //             namespace_key: None,
+    //             key: k.to_string(),
+    //         })
+    //         .await?;
+    // }
+    //
     Ok(())
 }
 
-#[allow(dead_code)]
-fn write_output(tokens: &TokenSet, to: Option<String>) -> Result<()> {
+fn write_output(flags: Vec<Flag>, to: Option<String>) -> Result<()> {
     let mut out_writer: Box<dyn std::io::Write> = match to {
         Some(s) => Box::new(std::fs::File::create(s)?),
         None => Box::new(std::io::stdout()),
     };
 
-    for (k, v) in tokens {
-        for loc in v {
-            let t = Token {
-                key: k.to_string(),
-                loc: loc.clone(),
-            };
-
-            let json = serde_json::to_string(&t)?;
-            writeln!(out_writer, "{json}")?;
-        }
+    for f in flags {
+        let json = serde_json::to_string(&f)?;
+        writeln!(out_writer, "{json}")?;
     }
 
     Ok(())

--- a/src/types/flag.rs
+++ b/src/types/flag.rs
@@ -4,16 +4,16 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "camelCase")]
 pub struct Flag {
     pub namespace_key: String,
-    pub key: String,
-    pub loc: Location,
+    pub flag_key: String,
+    pub location: Location,
 }
 
 impl std::fmt::Display for Flag {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
-            "Namespace: {} Key: {} [{}]",
-            self.namespace_key, self.key, self.loc
+            "namespace_key: {} flag_key: {} [{}]",
+            self.namespace_key, self.flag_key, self.location
         )
     }
 }
@@ -30,7 +30,7 @@ impl std::fmt::Display for Location {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
-            "File: {} [Line: {}, Col: {}]",
+            "file: {} [line: {}, col: {}]",
             self.file, self.line, self.column
         )
     }

--- a/src/types/flag.rs
+++ b/src/types/flag.rs
@@ -1,17 +1,20 @@
-use std::collections::HashMap;
-
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Token {
+pub struct Flag {
+    pub namespace_key: String,
     pub key: String,
     pub loc: Location,
 }
 
-impl std::fmt::Display for Token {
+impl std::fmt::Display for Flag {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "Key: {} [{}]", self.key, self.loc)
+        write!(
+            f,
+            "Namespace: {} Key: {} [{}]",
+            self.namespace_key, self.key, self.loc
+        )
     }
 }
 
@@ -32,5 +35,3 @@ impl std::fmt::Display for Location {
         )
     }
 }
-
-pub type TokenSet = HashMap<String, Vec<Location>>;

--- a/src/types/flag.rs
+++ b/src/types/flag.rs
@@ -22,16 +22,18 @@ impl std::fmt::Display for Flag {
 #[serde(rename_all = "camelCase")]
 pub struct Location {
     pub file: String,
-    pub line: usize,
-    pub column: usize,
+    pub start_line: usize,
+    pub start_column: usize,
+    pub end_line: usize,
+    pub end_column: usize,
 }
 
 impl std::fmt::Display for Location {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
-            "file: {} [line: {}, col: {}]",
-            self.file, self.line, self.column
+            "file: {} start: [line: {}, col: {}] end: [line: {}, col: {}]",
+            self.file, self.start_line, self.start_column, self.end_line, self.end_column
         )
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,3 +1,3 @@
 pub mod args;
+pub mod flag;
 pub mod language;
-pub mod token;


### PR DESCRIPTION
Fixes: FLI-323 (mostly)

- Finds all `flagKey`s and `namespaceKey`s in Go code
- Captures `end_line` and `end_column` for method calls
- I reverted most of the work in #3 as I want to redo this using ListFlags to get all the flags from the server at once

## Example

```console
cargo run -- -l go
...
{"namespaceKey":"default","flagKey":"foo","location":{"file":"./examples/go/basic.go","startLine":14,"startColumn":64,"endLine":21,"endColumn":1}}
{"namespaceKey":"production","flagKey":"bar","location":{"file":"./examples/go/basic.go","startLine":23,"startColumn":63,"endLine":30,"endColumn":1}}
{"namespaceKey":"default","flagKey":"boz","location":{"file":"./examples/go/basic.go","startLine":32,"startColumn":63,"endLine":39,"endColumn":1}}
{"namespaceKey":"default","flagKey":"foo","location":{"file":"./examples/go/basic.go","startLine":41,"startColumn":60,"endLine":43,"endColumn":1}}
```
