### PR TITLE
fix(rules/go): ensure exact match on field flag key

### DIFF
--- a/rules/go.scm
+++ b/rules/go.scm
@@ -9,7 +9,7 @@
             (interpreted_string_literal) @namespace
           )?
           (keyed_element
-            (field_identifier) @_flagKey (#match? @_flagKey "(Key|FlagKey)")
+            (field_identifier) @_flagKey (#match? @_flagKey "^(Key|FlagKey)$")
             (interpreted_string_literal) @flag
           )
         ) 


### PR DESCRIPTION
I was observing unexpected behaviour when running this against `predictab-le/config`.
I was getting false positives because it was trying to find a flag key `ingestor` in the `default` namespace.

`ingestor` was the namespace, not the flag.
I added some debug statements to ffs (print func name, namespace and flag key):
```
GetFlag default "ingestor"
GetFlag "ingestor" "ingestFromDiscord"
{"namespaceKey":"default","flagKey":"ingestor","location":{"file":"./services/ingestd/main.go","startLine":20,"startColumn":15,"endLine":23,"endColumn":4}}
```

There should only be one match:
```
GetFlag "ingestor" "ingestFromDiscord"
```

This PR adjusts the field name match in the Go rules to ensure `Key|FlagKey` match the entire string:
```
^(Key|FlagKey)$
```