### PR TITLE
feat: allow overriding of exit code in case missing flags were found

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,13 +11,15 @@ use futures::future::join_all;
 #[derive(Parser, Clone, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
+    #[arg(long, default_value = "1", help = "Override exit code on issues found")]
+    pub issue_exit_code: u8,
     #[arg(short, long, value_enum)]
     pub language: types::language::SupportedLanguage,
-    #[arg(short, long, help = "Path to output file (default: STDOUT)")]
+    #[arg(short, long, help = "Path to output file [default: STDOUT]")]
     pub output: Option<String>,
-    #[arg(short, long, help = "Path to directory to scan (default: .)")]
+    #[arg(short, long, help = "Path to directory to scan [default: .]")]
     pub dir: Option<String>,
-    #[arg(short, long, help = "Namespace to scan (default: 'default')")]
+    #[arg(short, long, help = "Namespace to scan [default: 'default']")]
     pub namespace: Option<String>,
 }
 
@@ -93,6 +95,7 @@ async fn main() -> Result<ExitCode> {
         };
         let json = serde_json::to_string(&results)?;
         writeln!(out_writer, "{json}")?;
+        return Ok(ExitCode::from(args.issue_exit_code));
     }
 
     Ok(ExitCode::SUCCESS)


### PR DESCRIPTION
taking a page from [`golangci-lint`](https://github.com/search?q=repo%3Agolangci%2Fgolangci-lint-action%20issues-exit-code&type=code), allow overriding the exit code value for any issues found (missing flags).

this can be helpful in CI situations, and we'll be using it in our own CI for testing the action itself

```
workspace/ffs - [exit-code] » cargo run -- --help

A CLI tool to find Flipt feature flags in code

Usage: ffs [OPTIONS] --language <LANGUAGE>

Options:
      --issue-exit-code <ISSUE_EXIT_CODE>  Override exit code on issues found [default: 1]
  -l, --language <LANGUAGE>                [possible values: go]
  -o, --output <OUTPUT>                    Path to output file [default: STDOUT]
  -d, --dir <DIR>                          Path to directory to scan [default: .]
  -n, --namespace <NAMESPACE>              Namespace to scan [default: 'default']
  -h, --help                               Print help
  -V, --version                            Print version
```