### PR TITLE
feat: support Eval v2

### DIFF
--- a/examples/go/basic.go
+++ b/examples/go/basic.go
@@ -46,9 +46,8 @@ func main() {
 	}
 
 	_, err = client.Flipt().Evaluate(context.TODO(), &flipt.EvaluationRequest{
-		EntityId:     "1",
-		NamespaceKey: "default",
-		FlagKey:      "boz",
+		EntityId: "1",
+		FlagKey:  "boz",
 		Context: map[string]string{
 			"bar": "boz",
 		},

--- a/examples/go/evaluation.go
+++ b/examples/go/evaluation.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"context"
+
+	evaluation "go.flipt.io/flipt/rpc/flipt/evaluation"
+	sdk "go.flipt.io/flipt/sdk/go"
+	sdkhttp "go.flipt.io/flipt/sdk/go/http"
+)
+
+func main() {
+	transport := sdkhttp.NewTransport("http://localhost:8080")
+
+	client := sdk.New(transport)
+
+	// this is a comment that mentions the FlagKey 'foo' but should not be included in the output
+	_, err := client.Evaluation().Boolean(context.TODO(), &evaluation.EvaluationRequest{
+		RequestId:    "123",
+		EntityId:     "1",
+		NamespaceKey: "default",
+		FlagKey:      "foo",
+		Context: map[string]string{
+			"bar": "boz",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	_, err = client.Evaluation().Variant(context.TODO(), &evaluation.EvaluationRequest{
+		RequestId:    "123",
+		EntityId:     "1",
+		NamespaceKey: "production",
+		FlagKey:      "bar",
+		Context: map[string]string{
+			"bar": "boz",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// defining a slice of requests outside of the function call
+	reqs := []*evaluation.EvaluationRequest{
+		{
+			EntityId:     "1",
+			NamespaceKey: "production",
+			FlagKey:      "bar",
+			Context: map[string]string{
+				"bar": "boz",
+			},
+		},
+		{
+			EntityId: "1",
+			FlagKey:  "bar",
+			Context: map[string]string{
+				"bar": "boz",
+			},
+		},
+	}
+
+	_, err = client.Evaluation().Batch(context.TODO(), &evaluation.BatchEvaluationRequest{
+		RequestId: "123",
+		Requests:  reqs,
+	})
+	// defining a slice of requests outside of the function call
+	[]*evaluation.EvaluationRequest{
+		{
+			EntityId:     "1",
+			NamespaceKey: "production",
+			FlagKey:      "bar",
+			Context: map[string]string{
+				"bar": "boz",
+			},
+		},
+		{
+			EntityId: "1",
+			FlagKey:  "bar",
+			Context: map[string]string{
+				"bar": "boz",
+			},
+		},
+	}
+
+	// defining a slice of requests inside of the function call
+	_, err = client.Evaluation().Batch(context.TODO(), &evaluation.BatchEvaluationRequest{
+		RequestId: "123",
+		Requests: []*evaluation.EvaluationRequest{
+			{
+				EntityId:     "1",
+				NamespaceKey: "production",
+				FlagKey:      "bar",
+				Context: map[string]string{
+					"bar": "boz",
+				},
+			},
+			{
+				EntityId: "1",
+				FlagKey:  "bar",
+				Context: map[string]string{
+					"bar": "boz",
+				},
+			},
+		},
+	})
+}

--- a/examples/go/evaluation.go
+++ b/examples/go/evaluation.go
@@ -63,24 +63,6 @@ func main() {
 		RequestId: "123",
 		Requests:  reqs,
 	})
-	// defining a slice of requests outside of the function call
-	[]*evaluation.EvaluationRequest{
-		{
-			EntityId:     "1",
-			NamespaceKey: "production",
-			FlagKey:      "bar",
-			Context: map[string]string{
-				"bar": "boz",
-			},
-		},
-		{
-			EntityId: "1",
-			FlagKey:  "bar",
-			Context: map[string]string{
-				"bar": "boz",
-			},
-		},
-	}
 
 	// defining a slice of requests inside of the function call
 	_, err = client.Evaluation().Batch(context.TODO(), &evaluation.BatchEvaluationRequest{

--- a/rules/go.scm
+++ b/rules/go.scm
@@ -1,19 +1,40 @@
 (call_expression
-  function: (_ (field_identifier) @_name (#match? @_name "(GetFlag|Evaluate)"))
-  arguments: (_ 
+  function: (selector_expression
+    field: (field_identifier) @method (#match? @method "(GetFlag|Evaluate|Boolean|Variant)"))
+  arguments: (argument_list
     (unary_expression
-      operand: (_
-        body: (_ 
+      operand: (composite_literal
+        type: (qualified_type
+          name: (type_identifier) @type_name (#match? @type_name "(GetFlagRequest|EvaluationRequest)"))
+        body: (literal_value
           (keyed_element
-            (field_identifier) @_namespaceKey (#match? @_namespaceKey "NamespaceKey")
-            (interpreted_string_literal) @namespace
-          )?
+            (field_identifier) @namespace_key (#eq? @namespace_key "NamespaceKey")
+            (interpreted_string_literal) @namespace_value)
           (keyed_element
-            (field_identifier) @_flagKey (#match? @_flagKey "^(Key|FlagKey)$")
-            (interpreted_string_literal) @flag
-          )
-        ) 
-      ) 
-    ) 
+            (field_identifier) @flag_key (#match? @flag_key "^(Key|FlagKey)$")
+            (interpreted_string_literal) @flag_value)
+        )
+      )
+    )
   )
 ) @call
+
+(call_expression
+  function: (selector_expression
+    field: (field_identifier) @method (#match? @method "(GetFlag|Evaluate|Boolean|Variant)"))
+  arguments: (argument_list
+    (unary_expression
+      operand: (composite_literal
+        type: (qualified_type
+          name: (type_identifier) @type_name (#match? @type_name "(GetFlagRequest|EvaluationRequest)"))
+        body: (literal_value
+          (keyed_element
+            (field_identifier) @flag_key (#match? @flag_key "^(Key|FlagKey)$")
+            (interpreted_string_literal) @flag_value)
+        )
+      )
+    )
+  )
+) @call
+
+

--- a/rules/go.scm
+++ b/rules/go.scm
@@ -19,6 +19,7 @@
   )
 ) @call
 
+;; This is the same as above, but with the namespace key omitted for matching optional namespace
 (call_expression
   function: (selector_expression
     field: (field_identifier) @method (#match? @method "(GetFlag|Evaluate|Boolean|Variant)"))
@@ -36,5 +37,3 @@
     )
   )
 ) @call
-
-

--- a/src/ffs/scanner.rs
+++ b/src/ffs/scanner.rs
@@ -71,7 +71,6 @@ impl Scanner {
                 // root node of the query match
                 let root = captures["call"];
 
-
                 let namespace_key = match captures.get("namespace_value") {
                     Some(n) => n.node.utf8_text(code.as_bytes()).unwrap(),
                     None => "default",

--- a/src/ffs/scanner.rs
+++ b/src/ffs/scanner.rs
@@ -71,12 +71,13 @@ impl Scanner {
                 // root node of the query match
                 let root = captures["call"];
 
-                let namespace_key = match captures.get("namespace") {
+
+                let namespace_key = match captures.get("namespace_value") {
                     Some(n) => n.node.utf8_text(code.as_bytes()).unwrap(),
                     None => "default",
                 };
 
-                let flag_key = match captures.get("flag") {
+                let flag_key = match captures.get("flag_value") {
                     Some(n) => n.node.utf8_text(code.as_bytes()).unwrap(),
                     None => "",
                 };


### PR DESCRIPTION
Fixes: FLI-512

- Adds support for new Boolean and Variant Evaluation calls: https://www.flipt.io/docs/reference/overview#v1-24-0
- Fixes support for 'optional' namespaceKey by adding a second Tree-Sitter query which is basically a duplicate of the first but with `namespaceKey` ommited. This required me to switch to using a `HashMap` to storing the captured code since the non-namespaced version would also match code that does contain the namespace, and we want the first query to take precedence.

TS expression re-write was made possible by ChatGPT 🤖 

BatchEval support is going to be a bit more complicated, but that is a different issue: FLI-337

## Output:

```
Found 6 results

- Found flag: [key: bar, namespace: production]
  File: ./examples/go/evaluation.go
  Line: { Start: 30, End: 38 }
  Column: { Start: 11, End: 4 }

- Found flag: [key: bar, namespace: production]
  File: ./examples/go/basic.go
  Line: { Start: 36, End: 43 }
  Column: { Start: 11, End: 4 }

- Found flag: [key: foo, namespace: default]
  File: ./examples/go/basic.go
  Line: { Start: 24, End: 31 }
  Column: { Start: 11, End: 4 }

- Found flag: [key: foo, namespace: default]
  File: ./examples/go/evaluation.go
  Line: { Start: 17, End: 25 }
  Column: { Start: 12, End: 4 }

- Found flag: [key: boz, namespace: default]
  File: ./examples/go/basic.go
  Line: { Start: 48, End: 54 }
  Column: { Start: 11, End: 4 }

- Found flag: [key: foo, namespace: default]
  File: ./examples/go/basic.go
  Line: { Start: 59, End: 61 }
  Column: { Start: 15, End: 4 }
```

