### PR TITLE
chore: notarize macos build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,12 +112,15 @@ jobs:
           curl -sSfL https://raw.githubusercontent.com/anchore/quill/main/install.sh | sh -s -- -b $GITHUB_WORKSPACE/bin
           echo "${GITHUB_WORKSPACE}/bin" >> $GITHUB_PATH
 
-      - name: Sign Binary
+      - name: Sign and Notarize Binary
         run: |
-          quill sign target/${{ matrix.target }}/release/ffs
+          quill sign-and-notarize -w=false target/${{ matrix.target }}/release/ffs
         env:
           QUILL_SIGN_P12: ${{ secrets.QUILL_SIGN_P12 }}
           QUILL_SIGN_PASSWORD: ${{ secrets.QUILL_SIGN_PASSWORD }}
+          QUILL_NOTARY_ISSUER: ${{ secrets.QUILL_NOTARY_ISSUER }}
+          QUILL_NOTARY_KEY: ${{ secrets.QUILL_NOTARY_KEY }}
+          QUILL_NOTARY_KEY_ID: ${{ secrets.QUILL_NOTARY_KEY_ID }}
 
       - name: Package
         shell: bash


### PR DESCRIPTION
Submit for notarization, otherwise we get the following error when trying to run:

![CleanShot 2023-09-04 at 15 13 59](https://github.com/flipt-io/ffs/assets/209477/e0448758-6961-4448-90fa-ce8ef5c0b2a1)
