### PR TITLE
feat: allow for unknown arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,13 +366,11 @@ dependencies = [
  "clap",
  "colored",
  "flipt",
- "futures",
  "human-panic",
  "rust-embed",
  "serde",
  "serde_json",
  "snailquote",
- "tokio",
  "tree-sitter",
  "tree-sitter-go",
  "tree-sitter-rust",
@@ -409,28 +407,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -438,34 +420,6 @@ name = "futures-core"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.31",
-]
 
 [[package]]
 name = "futures-sink"
@@ -485,16 +439,10 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
- "slab",
 ]
 
 [[package]]
@@ -560,15 +508,6 @@ name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -782,16 +721,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
-name = "lock_api"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,16 +782,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
-dependencies = [
- "hermit-abi 0.2.6",
- "libc",
-]
-
-[[package]]
 name = "object"
 version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,29 +805,6 @@ dependencies = [
  "log",
  "serde",
  "winapi",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -945,15 +841,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -1118,12 +1005,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
 name = "scratch"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,15 +1084,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1219,12 +1091,6 @@ checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "smallvec"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "snailquote"
@@ -1334,24 +1200,9 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "num_cpus",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
- "tokio-macros",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.31",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -298,7 +298,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.11",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -315,7 +315,7 @@ checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -464,7 +464,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -931,18 +931,18 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.53"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -1141,29 +1141,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.159"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.159"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 2.0.31",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.95"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
+checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
  "itoa",
  "ryu",
@@ -1271,9 +1271,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.11"
+version = "2.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e3787bb71465627110e7d87ed4faaa36c1f61042ee67badb9e2ef173accc40"
+checksum = "718fa2415bcb8d8bd775917a1bf12a7931b6dfa890753378538118181e0cb398"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1306,7 +1306,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -1351,7 +1351,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 2.0.31",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ futures = "0.3.28"
 human-panic = "1.1.3"
 rust-embed = "6.6.1"
 serde = "1.0.159"
-serde_json = "1.0.95"
+serde_json = "1.0.105"
 snailquote = "0.3.1"
 tokio = { version = "1", features = ["full"] }
 tree-sitter = "0.20.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ffs"
 version = "0.0.17"
-description =  "A CLI tool to find Flipt feature flags in code"
+description = "A CLI tool to find Flipt feature flags in code"
 edition = "2021"
 authors = ["Flipt Dev <dev@flipt.io>"]
 homepage = "https://github.com/flipt-io/ffs"
@@ -14,13 +14,11 @@ license = "Apache-2.0"
 anyhow = "1.0.70"
 clap = { version = "4.2.0", features = ["derive"] }
 flipt = "0.4.4"
-futures = "0.3.28"
 human-panic = "1.1.3"
 rust-embed = "6.6.1"
 serde = "1.0.159"
 serde_json = "1.0.105"
 snailquote = "0.3.1"
-tokio = { version = "1", features = ["full"] }
 tree-sitter = "0.20.9"
 tree-sitter-go = "0.19.1"
 tree-sitter-rust = "0.20.3"

--- a/examples/go/evaluation.go
+++ b/examples/go/evaluation.go
@@ -13,8 +13,7 @@ func main() {
 
 	client := sdk.New(transport)
 
-	// this is a comment that mentions the FlagKey 'foo' but should not be included in the output
-	_, err := client.Evaluation().Boolean(context.TODO(), &evaluation.EvaluationRequest{
+	req := &evaluation.EvaluationRequest{
 		RequestId:    "123",
 		EntityId:     "1",
 		NamespaceKey: "default",
@@ -22,7 +21,9 @@ func main() {
 		Context: map[string]string{
 			"bar": "boz",
 		},
-	})
+	}
+	// this is a comment that mentions the FlagKey 'foo' but should not be included in the output
+	_, err := client.Evaluation().Boolean(context.TODO(), req)
 	if err != nil {
 		panic(err)
 	}

--- a/rules/go.scm
+++ b/rules/go.scm
@@ -16,7 +16,7 @@
         )
       )
     )
-  )
+  )?
 ) @call
 
 ;; This is the same as above, but with the namespace key omitted for matching optional namespace
@@ -35,5 +35,5 @@
         )
       )
     )
-  )
+  )?
 ) @call

--- a/rules/go.scm
+++ b/rules/go.scm
@@ -16,7 +16,7 @@
         )
       )
     )
-  )?
+  ) ? @args
 ) @call
 
 ;; This is the same as above, but with the namespace key omitted for matching optional namespace
@@ -35,5 +35,5 @@
         )
       )
     )
-  )?
+  ) ? @args
 ) @call

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,8 +28,7 @@ pub enum Format {
     Text,
 }
 
-#[tokio::main]
-async fn main() -> Result<ExitCode> {
+fn main() -> Result<ExitCode> {
     setup_panic!();
 
     let args = Args::parse();

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,31 +33,52 @@ fn main() -> Result<ExitCode> {
 
     let args = Args::parse();
 
-    let mut ffs = Scanner::new(args.language, args.dir);
-
-    let found_flags = ffs.scan()?;
-
     let mut out_writer: Box<dyn std::io::Write> = match args.output {
         Some(s) => Box::new(std::fs::File::create(s)?),
         None => Box::new(std::io::stdout()),
     };
 
-    if !found_flags.is_empty() {
-        let results = found_flags
+    let mut ffs = Scanner::new(args.language, args.dir);
+
+    let found_flags = ffs.scan()?;
+    let filtered_flags = match args.namespace {
+        Some(s) => found_flags
             .into_iter()
-            .filter(|f| {
-                if let Some(ns) = &args.namespace {
-                    f.namespace_key == *ns
-                } else {
-                    true
-                }
+            .filter(|f| match &f.namespace_key {
+                Some(n) => n == &s,
+                None => false,
             })
-            .map(|f| Res {
-                message: format!(
-                    "Found flag: [key: {}, namespace: {}]",
-                    f.key, f.namespace_key
-                ),
-                flag: f,
+            .collect(),
+        None => found_flags,
+    };
+
+    if !filtered_flags.is_empty() {
+        let results = filtered_flags
+            .into_iter()
+            .map(|f| {
+                if f.namespace_key.is_none() && f.key.is_none() {
+                    Res {
+                        message: "Found flag".to_string(),
+                        flag: f,
+                    }
+                } else {
+                    let namespace_key = match &f.namespace_key {
+                        Some(s) => s,
+                        None => "default",
+                    };
+
+                    let key = match &f.key {
+                        Some(s) => s,
+                        None => "unknown",
+                    };
+                    Res {
+                        message: format!(
+                            "Found flag: [key: {}, namespace: {}]",
+                            key, namespace_key
+                        ),
+                        flag: f,
+                    }
+                }
             })
             .collect();
 

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -79,7 +79,7 @@ impl Scanner {
 
                 let flag_key = match captures.get("flag_value") {
                     Some(n) => n.node.utf8_text(code.as_bytes()).unwrap(),
-                    None => "",
+                    None => "unknown",
                 };
 
                 let range = root.node.range();

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -72,38 +72,54 @@ impl Scanner {
                 // root node of the query match
                 let root = captures["call"];
 
-                let namespace_key = match captures.get("namespace_value") {
-                    Some(n) => n.node.utf8_text(code.as_bytes()).unwrap(),
-                    None => "default",
-                };
-
-                let flag_key = match captures.get("flag_value") {
-                    Some(n) => n.node.utf8_text(code.as_bytes()).unwrap(),
-                    None => "unknown",
-                };
-
                 let range = root.node.range();
 
                 let file = path;
                 let start_line = range.start_point.row + 1;
                 let end_line = range.end_point.row + 1;
 
-                flags
-                    .entry(format!("{file}/{start_line}/{end_line}"))
-                    .or_insert(Flag {
-                        namespace_key: unescape(namespace_key).unwrap(),
-                        key: unescape(flag_key).unwrap(),
-                        location: Location {
-                            file: file.to_string(),
-                            start_line,
-                            start_column: range.start_point.column + 1,
-                            end_line,
-                            end_column: range.end_point.column + 1,
-                        },
-                    });
+                let implicit = match captures.get("args") {
+                    Some(_n) => false,
+                    None => true,
+                };
+
+                let location = Location {
+                    file: file.to_string(),
+                    start_line,
+                    start_column: range.start_point.column + 1,
+                    end_line,
+                    end_column: range.end_point.column + 1,
+                };
+
+                if !implicit {
+                    let namespace_key = match captures.get("namespace_value") {
+                        Some(n) => n.node.utf8_text(code.as_bytes()).unwrap(),
+                        None => "default",
+                    };
+
+                    let flag_key = match captures.get("flag_value") {
+                        Some(n) => n.node.utf8_text(code.as_bytes()).unwrap(),
+                        None => "unknown",
+                    };
+
+                    flags
+                        .entry(format!("{file}/{start_line}/{end_line}"))
+                        .or_insert(Flag {
+                            namespace_key: Some(unescape(namespace_key).unwrap()),
+                            key: Some(unescape(flag_key).unwrap()),
+                            location,
+                        });
+                } else {
+                    flags
+                        .entry(format!("{file}/{start_line}/{end_line}"))
+                        .or_insert(Flag {
+                            namespace_key: None,
+                            key: None,
+                            location,
+                        });
+                }
             }
         }
-
         Ok(flags.values().cloned().collect())
     }
 }

--- a/src/types/flag.rs
+++ b/src/types/flag.rs
@@ -5,17 +5,32 @@ use super::location::Location;
 #[derive(Debug, Serialize, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Flag {
-    pub namespace_key: String,
-    pub key: String,
+    pub namespace_key: Option<String>,
+    pub key: Option<String>,
     pub location: Location,
 }
 
 impl std::fmt::Display for Flag {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        if self.namespace_key.is_none() && self.key.is_none() {
+            write!(f, "[{}]", self.location)?;
+            return Ok(());
+        }
+
+        let namespace_key = match &self.namespace_key {
+            Some(s) => s,
+            None => "default",
+        };
+
+        let key = match &self.key {
+            Some(s) => s,
+            None => "unknown",
+        };
+
         write!(
             f,
             "namespace_key: {} key: {} [{}]",
-            self.namespace_key, self.key, self.location
+            namespace_key, key, self.location
         )
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -8,5 +8,5 @@ fn test_scan_go() {
         .unwrap();
 
     assert_eq!(results.len(), 6);
-    assert!(results.iter().any(|f| f.key == "foo"));
+    assert!(results.iter().any(|f| f.key.as_ref().unwrap() == "foo"));
 }


### PR DESCRIPTION
Fixes: #55 

-  Allow for finding calls without argument literals
- remove unneeded dependencies

Output (truncated):

```
- Found flag
  File: ./examples/go/evaluation.go
  Line: { Start: 26, End: 26 }
  Column: { Start: 12, End: 60 }
```